### PR TITLE
add tracedock aws loadbalancers

### DIFF
--- a/domains
+++ b/domains
@@ -25,3 +25,10 @@ dnsdelegation.io
 
 # Commanders Act
 tagcommander.com
+
+# TraceDock
+# Clients setup CNAME records for a subdomain of their choice that map to one of TraceDocks
+# aws load balancers. These were discovered via customer sites, such as beta.simpel.nl,
+# lease.leasevergelijker.nl and pc3.vanmoof.com.
+a88045584548111e997c60ac8a4ec150-1610510072.eu-central-1.elb.amazonaws.com
+afc4d9aa2a91d11e997c60ac8a4ec150-2082092489.eu-central-1.elb.amazonaws.com


### PR DESCRIPTION
Hey folks. Not sure if you're interested in this but I'm adding these domains to my own block list and thought others might benefit too. Not sure what the risk is with adding these but thought it was worth a shot.

tracedock.com offers customers a way to bypass ad blockers by hosting scrips under a subdomain of their own site and mapping to tracedock's servers. Seems like they just have customers add a cname record that points at one of a few aws load balancer instances.

These are the few I found by poking around their customers sites and looking for the common script.