### PR TITLE
Added ThreatMetrix, Webtrekk and Otto Group

### DIFF
--- a/domains
+++ b/domains
@@ -35,3 +35,12 @@ afc4d9aa2a91d11e997c60ac8a4ec150-2082092489.eu-central-1.elb.amazonaws.com
 
 # Ingenious Technologies
 affex.org
+
+# ThreatMetrix
+online-metrix.net
+
+# Webtrekk
+wt-eu02.net
+
+# Otto Group
+oghub.io


### PR DESCRIPTION
If you need some examples in the wild:

- ThreatMetrix can be seen on https://www.discover.com (`content.discover.com`)
- Webtrekk can be seen on https://www.mytoys.de (`web.mytoys.de`)
- Otto Group can be seen on https://www.baur.de (`tp.baur.de`)

I found one more that can be found on https://www.liligo.com (`compare.liligo.com`) that would be matched with `partner.intentmedia.net` but I could not find any information on the entity serving this.

Do you mind sharing the methodology you used to find the entity name behind the tracker `affex.org` (Ingenious Technologies)? Maybe the same methodology can be applied here.
