### PR TITLE
Update domains and add NP6, A8, Ebis

### DIFF
--- a/domains
+++ b/domains
@@ -28,9 +28,6 @@ criteo.com
 storetail.io
 dnsdelegation.io
 
-# ThreatMetrix
-online-metrix.net
-
 # Commanders Act
 tagcommander.com
 

--- a/domains
+++ b/domains
@@ -11,17 +11,25 @@ eulerian.net
 
 # AT Internet (formerly XiTi)
 at-o.net
+ati-host.net
+
+# NP6
+bp01.net
 
 # Keyade
-k.keyade.com
+keyade.com
 
 # Adobe Experience Cloud (formerly Omniture)
 2o7.net
-sc.omtrdc.net
+omtrdc.net
 
 # Criteo
+criteo.com
 storetail.io
 dnsdelegation.io
+
+# ThreatMetrix
+online-metrix.net
 
 # Commanders Act
 tagcommander.com
@@ -45,3 +53,10 @@ wt-eu02.net
 
 # Otto Group
 oghub.io
+
+# A8
+trck.a8.net
+
+# Ebis
+# https://prtimes.jp/main/html/rd/p/000000215.000009812.html
+ebis.ne.jp


### PR DESCRIPTION
I basically did a sync with @GeoffreyFrogeye's list: https://git.frogeye.fr/geoffrey/eulaurarien/src/branch/master/rules/first-party.list.

Updates to domains:
- remove subdomain `k.` from `keyade.com`. According to @GeoffreyFrogeye's hosts file all tracking subdomains go in format of `subdomain.keyade.com`;
- remove subdomain `sc.` from `omtrdc.net`. There is at least `heartbeats.omtrdc.net` which is blocked by other hosts file as well;
- added `criteo.com` as there are ads subdomains such as `advertising.criteo.com`, this domain also is found in other block lists.

New companies:
- NP6 is a French tracking company.
- A8 and Ebis are two Japanese trackers.

All credits to @GeoffreyFrogeye.