### PR TITLE
Update CNAME tracking domains Adobe

### DIFF
--- a/domains
+++ b/domains
@@ -18,6 +18,7 @@ k.keyade.com
 # Adobe Experience Cloud (formerly Omniture)
 2o7.net
 sc.omtrdc.net
+data.adobedc.net
 
 # Criteo
 dnsdelegation.io


### PR DESCRIPTION
Adobe added "data.adobedc.net" as a tracking domain according to 
https://experienceleague.adobe.com/docs/analytics/implementation/vars/config-vars/trackingserversecure.html?lang=en#ssl-tracking-server-in-adobe-experience-platform-launch
They also mention "sc.adobedc.net" as being used instead of "sc.omtrdc.net", but I haven't encountered CNAME records to it yet